### PR TITLE
Fixes error when installing

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -29,7 +29,7 @@ class Settings extends Model
 	 *
 	 * @var array<non-empty-string, Index>
 	 */
-	public array $indices;
+	public array $indices = [];
 
 	/**
 	 * @param array{


### PR DESCRIPTION
When trying to install the plugin the following error was appearing

`Typed property fostercommerce\meilisearch\models\Settings::$indices must not be accessed before initialization`

By initialising the $indices property as an empty array it prevents this.