### PR TITLE
Fix pagination

### DIFF
--- a/src/variables/Search.php
+++ b/src/variables/Search.php
@@ -30,10 +30,10 @@ class Search extends Component
 
 		return [
 			'results' => $results['results'],
-			'pagination' => Craft::createObject(
-				Paginate::class,
-				[$results['pagination']],
-			),
+			'pagination' => Craft::createObject([
+				'class' => Paginate::class,
+				...$results['pagination'],
+			]),
 		];
 	}
 }

--- a/src/variables/Search.php
+++ b/src/variables/Search.php
@@ -28,11 +28,17 @@ class Search extends Component
 		];
 		$results = Plugin::getInstance()->search->search($indexHandle, $query, $searchParams, $options);
 
+
+
 		return [
 			'results' => $results['results'],
 			'pagination' => Craft::createObject([
 				'class' => Paginate::class,
-				...$results['pagination'],
+				'first' => $results['pagination']['first'],
+				'last' => $results['pagination']['last'],
+				'total' => $results['pagination']['total'],
+				'currentPage' => $results['pagination']['currentPage'],
+				'totalPages' => $results['pagination']['totalPages'],
 			]),
 		];
 	}

--- a/src/variables/Search.php
+++ b/src/variables/Search.php
@@ -32,7 +32,7 @@ class Search extends Component
 			'results' => $results['results'],
 			'pagination' => Craft::createObject(
 				Paginate::class,
-				$results['pagination'],
+				[$results['pagination']],
 			),
 		];
 	}


### PR DESCRIPTION
Fixes how the Meilisearch pagination info is used to create the Craft Pagination object to allow use of regular Craft pagination without doing another query.