### PR TITLE
change Model type for EVENT_AFTER_DELETE

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,7 +7,6 @@ use craft\base\Element;
 use craft\base\Model;
 use craft\base\Plugin as BasePlugin;
 use craft\elements\db\ElementQuery;
-use craft\events\ModelEvent;
 use craft\helpers\ElementHelper;
 use craft\helpers\Queue;
 use craft\web\twig\variables\CraftVariable;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -103,7 +103,7 @@ class Plugin extends BasePlugin
 			Event::on(
 				Element::class,
 				Element::EVENT_AFTER_DELETE,
-				static function (ModelEvent $event) use ($autoSyncIndices): void {
+				static function (Event $event) use ($autoSyncIndices): void {
 					/** @var Element $sender */
 					$sender = $event->sender;
 					$autoSyncIndices->each(static function (Index $index) use ($sender): void {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,7 @@ use craft\base\Element;
 use craft\base\Model;
 use craft\base\Plugin as BasePlugin;
 use craft\elements\db\ElementQuery;
+use craft\events\ModelEvent;
 use craft\helpers\ElementHelper;
 use craft\helpers\Queue;
 use craft\web\twig\variables\CraftVariable;
@@ -69,7 +70,7 @@ class Plugin extends BasePlugin
 			Event::on(
 				Element::class,
 				Element::EVENT_AFTER_SAVE,
-				static function (Event $event) use ($autoSyncIndices): void {
+				static function (ModelEvent $event) use ($autoSyncIndices): void {
 					/** @var Element $sender */
 					$sender = $event->sender;
 


### PR DESCRIPTION
fixes the event type used for the EVENT_AFTER_DELETE listener

I'm not 100% this is going to work though. The error message I was getting on staging indicated that it required Event rather than ModelEvent