### PR TITLE
Allow fetch functions to return multiple documents per entry

### DIFF
--- a/src/services/Sync.php
+++ b/src/services/Sync.php
@@ -173,8 +173,27 @@ class Sync extends Component
 		foreach ($index->execFetchFn($identifier) as $chunk) {
 			$size = count($chunk);
 
-			// Remove any falsy values from the chunk of data.
-			$chunk = array_values(array_filter($chunk));
+			// Remove any falsy values from the chunk of data
+			// and flatten list arrays.
+			$chunk = array_values(
+				array_merge(
+					...array_map(
+						static function ($item) {
+							if (!$item) {
+								return [];
+							}
+
+							if (array_is_list($item)) {
+								return $item;
+							}
+
+							return [$item];
+						},
+						$chunk,
+					),
+				),
+			);
+
 			$this->meiliClient
 				->index($index->indexId)
 				->addDocuments($chunk, $index->getSettings()->primaryKey);


### PR DESCRIPTION
In our case we need to be able to create multiple MeiliSearch documents per Craft entry. This PR allows to return an array of associative arrays from the transformator function.