### PR TITLE
Fix sync job progress starting over for each index

### DIFF
--- a/src/jobs/Sync.php
+++ b/src/jobs/Sync.php
@@ -42,7 +42,7 @@ class Sync extends BaseJob
 			: 0;
 
 		$currentPage = 0;
-		$indices->each(function ($index) use ($queue, $totalPages, $currentPage): void {
+		$indices->each(function ($index) use ($queue, $totalPages, &$currentPage): void {
 			foreach (Plugin::getInstance()->sync->sync($index, $this->identifier) as $chunkSize) {
 				++$currentPage;
 


### PR DESCRIPTION
Just a small issue: Because `$currentPage` was not passed as reference, it begins counting from 0 for each index.